### PR TITLE
feat: добавить отображение Now Playing для CINEMIX через Icecast API

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,9 @@ function fetchNowPlaying(url) {
       } else if (response.songs && response.songs[0]) {
         var s = response.songs[0];
         title = [s.artist, s.title].filter(Boolean).join(' - ');
+      } else if (response.icestats && response.icestats.source) {
+        var src = Array.isArray(response.icestats.source) ? response.icestats.source[0] : response.icestats.source;
+        if (src && src.title) title = src.title;
       } else if (response.artist || response.title) {
         title = [response.artist, response.title].filter(Boolean).join(' - ');
       }

--- a/stations.json
+++ b/stations.json
@@ -148,7 +148,7 @@
     "url": "https://kathy.torontocast.com:1825/stream",
     "category": "",
     "group": "Radio World",
-    "nowplaying_url": "",
+    "nowplaying_url": "https://kathy.torontocast.com:1825/status-json.xsl",
     "type": "mp3"
   }
 ]


### PR DESCRIPTION
- Добавлен nowplaying_url для CINEMIX (kathy.torontocast.com:1825/status-json.xsl)
- Добавлен парсер Icecast JSON формата (icestats.source.title) в fetchNowPlaying